### PR TITLE
Stop using legacy syntax in stack.yaml

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -2,11 +2,10 @@ resolver: nightly-2018-12-12
 
 packages:
 - .
-- location:
-    git: https://github.com/jwaldmann/haskell_cudd
-    commit: df1142ce71df275f45d14c6f8fd9821675f754a8
-  extra-dep: True
 
+extra-deps:
+- git: https://github.com/jwaldmann/haskell_cudd.git
+  commit: df1142ce71df275f45d14c6f8fd9821675f754a8
 
 system-ghc: true
 


### PR DESCRIPTION
See https://docs.haskellstack.org/en/stable/yaml_configuration/#packages for details.

> Legacy syntax Prior to Stack 1.11, it was possible to specify dependencies in your `packages` configuration value as well. This support has been removed to simplify the file format. Instead, these values should be moved to `extra-deps`. 